### PR TITLE
Gmail - Supporting Rich Text in Message body

### DIFF
--- a/gmail/docs/gmail/README.md
+++ b/gmail/docs/gmail/README.md
@@ -21,6 +21,7 @@ The createDraft action helps to Creates a new draft with the DRAFT label.
 * bcc - To whom sender need to bcc the mail
 * id - Id of the draft to create
 * threadId - thread Id of the draft to reply
+* format - Format of the content, can be text (default) or html
 
 #### Related Gmail documentation
 [createDraft](https://developers.google.com/gmail/api/v1/reference/users/drafts/create)
@@ -39,6 +40,7 @@ The updateDraft action helps to Replaces a draft's content.
 * bcc - To whom sender need to bcc the mail
 * id - Id of the draft to update
 * threadId - thread Id of the draft to reply
+* format - Format of the content, can be text (default) or html
 
 #### Related Gmail documentation
 [updateDraft](https://developers.google.com/gmail/api/v1/reference/users/drafts/update)
@@ -234,6 +236,7 @@ The sendMail action helps to Sends the specified message to the recipients.
 * bcc - To whom sender need to bcc the mail
 * id - Id of the message to reply
 * threadId - To whom sender need to bcc the mail
+* format - Format of the content, can be text (default) or html
 
 #### Related Gmail documentation
 [sendMail](https://developers.google.com/gmail/api/v1/reference/users/messages/send)
@@ -318,9 +321,9 @@ The unTrashMail action helps to Removes the specified message from the trash.
 * getUserProfile  
 `bin$ ./ballerina run samples.bal getUserProfile <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional>`
 * createDraft  
-`bin$ ./ballerina run samples.bal createDraft  <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <to:-Optional> <subject:-Optional> <from:-Optional> <"messageBody":-Optional> <cc:-Optional> <bcc:-Optional> <id:-Optional> <threadId:-Optional>`
+`bin$ ./ballerina run samples.bal createDraft  <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <to:-Optional> <subject:-Optional> <from:-Optional> <"messageBody":-Optional> <cc:-Optional> <bcc:-Optional> <id:-Optional> <threadId:-Optional> <format:-Optional>`
 * updateDraft  
-`bin$ ./ballerina run samples.bal updateDraft <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <draftId:Required> <to:-Optional> <subject:-Optional> <from:-Optional> <"messageBody":-Optional> <cc:-Optional> <bcc:-Optional> <id:-Optional> <threadId:-Optional>`
+`bin$ ./ballerina run samples.bal updateDraft <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <draftId:Required> <to:-Optional> <subject:-Optional> <from:-Optional> <"messageBody":-Optional> <cc:-Optional> <bcc:-Optional> <id:-Optional> <threadId:-Optional> <format:-Optional>`
 * readDraft  
 `bin$ ./ballerina run samples.bal readDraft <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <draftId:-Required> <format:-Optional>`
 * listDrafts  
@@ -352,7 +355,7 @@ The unTrashMail action helps to Removes the specified message from the trash.
 * listMails  
 `bin$ ./ballerina run samples.bal listMails <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <includeSpamTrash:-Optional> <labelIds:-Optional> <maxResults:-Optional> <pageToken:-Optional> <q:-Optional>`
 * sendMail  
-`bin$ ./ballerina run samples.bal sendMail <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <to:-Optional> <subject:-Optional> <from:-Optional> <"messageBody":-Optional> <cc:-Optional> <bcc:-Optional> <id:-Optional> <threadId:-Optional>`
+`bin$ ./ballerina run samples.bal sendMail <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <to:-Optional> <subject:-Optional> <from:-Optional> <"messageBody":-Optional> <cc:-Optional> <bcc:-Optional> <id:-Optional> <threadId:-Optional> <format:-Optional>`
 * modifyExistingMessage  
 `bin$ ./ballerina run samples.bal modifyExistingMessage <userId:-Required> <accessToken:-Required> <refreshToken:-Optional> <clientId:-Optional> <clientSecret:-Optional> <messageId:-Required> <addLabelIds:-Either addLabelIds or removeLabelIds is required> <removeLabelIds:- Either addLabelIds or removeLabelIds is required>`
 * readMail  

--- a/gmail/samples/gmail/GmailConnector_test.bal
+++ b/gmail/samples/gmail/GmailConnector_test.bal
@@ -38,29 +38,72 @@ function testCreateDraft () {
     string messageBody = "This is test message";
     string cc = userId;
     string bcc = userId;
-    string id = "154b8c77e551c510";
-    string threadId = "154b8c77e551c510";
+    string id = "null";
+    string threadId = "null";
+    string format = "text";
     gmail:ClientConnector connectorInstance = init();
     gmailResponse = gmail:ClientConnector.createDraft (connectorInstance, recipientAddress, subject, from, messageBody
-                                                       , cc, bcc, id, threadId);
+                                                       , cc, bcc, id, threadId, format);
+    gmailJSONResponse = messages:getJsonPayload(gmailResponse);
+    string returnedId = (string)gmailJSONResponse.id;
+    string statusCode = (string)http:getStatusCode(gmailResponse);
+    test:assertTrue(!strings:equalsIgnoreCase(returnedId, "") && strings:equalsIgnoreCase(statusCode, "200"));
+
+    system:println(gmailJSONResponse);
+}
+
+function testCreateDraftHtml () {
+    string subject = "Test Message with Html body";
+    string from = userId;
+    string messageBody = "<i>This is test message</i>";
+    string cc = userId;
+    string bcc = userId;
+    string id = "null";
+    string threadId = "null";
+    string format = "html";
+    gmail:ClientConnector connectorInstance = init();
+    gmailResponse = gmail:ClientConnector.createDraft (connectorInstance, recipientAddress, subject, from, messageBody
+                                                       , cc, bcc, id, threadId, format);
+    gmailJSONResponse = messages:getJsonPayload(gmailResponse);
+    string returnedId = (string)gmailJSONResponse.id;
+    string statusCode = (string)http:getStatusCode(gmailResponse);
+    test:assertTrue(!strings:equalsIgnoreCase(returnedId, "") && strings:equalsIgnoreCase(statusCode, "200"));
+
+    system:println(gmailJSONResponse);
+}
+
+function testUpdateDraft () {
+    string draftId = "";
+    string subject = "Test Subject 1 updated";
+    string from = userId;
+    string messageBody = "Draft message body - Test content";
+    string cc = userId;
+    string bcc = userId;
+    string id = "";
+    string threadId = "";
+    string format = "text";
+    gmail:ClientConnector connectorInstance = init();
+    gmailResponse = gmail:ClientConnector.updateDraft (connectorInstance, draftId, recipientAddress, subject, from
+                                                       , messageBody, cc, bcc, id, threadId, format);
     gmailJSONResponse = messages:getJsonPayload(gmailResponse);
     string returnedId = (string)gmailJSONResponse.id;
     string statusCode = (string)http:getStatusCode(gmailResponse);
     test:assertTrue(!strings:equalsIgnoreCase(returnedId, "") && strings:equalsIgnoreCase(statusCode, "200"));
 }
 
-function testUpdateDraft () {
-    string draftId = "r-6158712664976689510";
+function testUpdateDraftHtml() {
+    string draftId = "";
     string subject = "Test Subject 1 updated";
     string from = userId;
-    string messageBody = "This is test message updated";
+    string messageBody = "<b><i>Draft mesage is updated with html content</i></b>";
     string cc = userId;
     string bcc = userId;
-    string id = "154b8c77e551c510";
-    string threadId = "154b8c77e551c510";
+    string id = "";
+    string threadId = "";
+    string format = "html";
     gmail:ClientConnector connectorInstance = init();
     gmailResponse = gmail:ClientConnector.updateDraft (connectorInstance, draftId, recipientAddress, subject, from
-                                                       , messageBody, cc, bcc, id, threadId);
+                                                       , messageBody, cc, bcc, id, threadId, format);
     gmailJSONResponse = messages:getJsonPayload(gmailResponse);
     string returnedId = (string)gmailJSONResponse.id;
     string statusCode = (string)http:getStatusCode(gmailResponse);
@@ -248,11 +291,31 @@ function testSendMails () {
     string messageBody = "Test message 1";
     string cc = userId;
     string bcc = userId;
-    string id = "154b8c77e551c511";
-    string threadId = "154b8c77e551c512";
+    string id = "null";
+    string threadId = "null";
+    string format = "text";
+    gmail:ClientConnector connectorInstance = init();
+
+    gmailResponse = gmail:ClientConnector.sendMail (connectorInstance, to, subject, from, messageBody
+                                                    , cc, bcc, id, threadId, format);
+    gmailJSONResponse = messages:getJsonPayload(gmailResponse);
+    string statusCode = (string)http:getStatusCode(gmailResponse);
+    test:assertTrue(strings:equalsIgnoreCase(statusCode, "200"));
+}
+
+function testSendMailsHtmlFormat () {
+    string to = recipientAddress;
+    string subject = "Test subject 1";
+    string from = userId;
+    string messageBody = "<p><b>Test message</b><br/><ul><li>One</li><li><b>Two</b></li><li><i>Three</i></li></ul></p>";
+    string cc = userId;
+    string bcc = userId;
+    string id = "null";
+    string threadId = "null";
+    string format = "html";
     gmail:ClientConnector connectorInstance = init();
     gmailResponse = gmail:ClientConnector.sendMail (connectorInstance, to, subject, from, messageBody
-                                                    , cc, bcc, id, threadId);
+                                                    , cc, bcc, id, threadId, format);
     gmailJSONResponse = messages:getJsonPayload(gmailResponse);
     string statusCode = (string)http:getStatusCode(gmailResponse);
     test:assertTrue(strings:equalsIgnoreCase(statusCode, "200"));

--- a/gmail/samples/gmail/samples.bal
+++ b/gmail/samples/gmail/samples.bal
@@ -21,14 +21,14 @@ function main (string[] args) {
 
     if( args[0] == "createDraft") {
         gmailResponse = gmail:ClientConnector.createDraft(gmailConnector , args[6], args[7], args[8],
-        args[9], args[10], args[11], args[12], args[13] );
+        args[9], args[10], args[11], args[12], args[13], args[14]);
         gmailJSONResponse = messages:getJsonPayload(gmailResponse);
         system:println(jsons:toString(gmailJSONResponse));
     }
 
     if( args[0] == "updateDraft") {
         gmailResponse = gmail:ClientConnector.updateDraft(gmailConnector, args[6], args[7], args[8], args[9],
-        args[10], args[11], args[12], args[13], args[14]);
+        args[10], args[11], args[12], args[13], args[14], args[15]);
         gmailJSONResponse = messages:getJsonPayload(gmailResponse);
         system:println(jsons:toString(gmailJSONResponse));
     }
@@ -124,7 +124,7 @@ function main (string[] args) {
 
     if( args[0] == "sendMail") {
         gmailResponse = gmail:ClientConnector.sendMail(gmailConnector, args[6], args[7], args[8], args[9], args[10], args[11],
-        args[12], args[13]);
+        args[12], args[13], args[14]);
         gmailJSONResponse = messages:getJsonPayload(gmailResponse);
         system:println(jsons:toString(gmailJSONResponse));
     }

--- a/gmail/src/org/wso2/ballerina/connectors/gmail/gmailConnector.bal
+++ b/gmail/src/org/wso2/ballerina/connectors/gmail/gmailConnector.bal
@@ -94,7 +94,8 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
         string encodedRequest = "";
 
         if(format == "html") {
-            encodedRequest = strings:replaceAll(utils:base64encode(concatRequest), "\\+","-");
+            encodedRequest = strings:replaceAll(strings:replaceAll(
+                                                    utils:base64encode(concatRequest), "\\+","-"),"/","_");
         } else {
             encodedRequest = utils:base64encode(concatRequest);
         }
@@ -167,7 +168,8 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
         string encodedRequest = "";
 
         if(format == "html") {
-            encodedRequest = strings:replaceAll(utils:base64encode(concatRequest), "\\+","-");
+            encodedRequest = strings:replaceAll(strings:replaceAll(
+                                                    utils:base64encode(concatRequest), "\\+","-"),"/","_");
         } else {
             encodedRequest = utils:base64encode(concatRequest);
         }
@@ -655,7 +657,8 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
         string encodedRequest = "";
 
         if(format == "html") {
-            encodedRequest = strings:replaceAll(utils:base64encode(concatRequest),"\\+","-");
+           encodedRequest = strings:replaceAll(strings:replaceAll(
+                                                   utils:base64encode(concatRequest), "\\+","-"),"/","_");
         } else {
             encodedRequest = utils:base64encode(concatRequest);
         }

--- a/gmail/src/org/wso2/ballerina/connectors/gmail/gmailConnector.bal
+++ b/gmail/src/org/wso2/ballerina/connectors/gmail/gmailConnector.bal
@@ -47,9 +47,10 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
     @doc:Param{ value : "bcc: To whom sender need to bcc the mail"}
     @doc:Param{ value : "id: Id of the draft to create"}
     @doc:Param{ value : "threadId: thread Id of the draft to reply"}
+    @doc:Param{ value : "format: Format of the content, can be text (default) or html"}
     @doc:Return{ value : "response object"}
     action createDraft(ClientConnector g, string to, string subject, string from, string messageBody,
-                       string cc , string bcc, string id, string threadId) (message) {
+                       string cc , string bcc, string id, string threadId, string format) (message) {
 
         message request = {};
         string concatRequest = "";
@@ -82,11 +83,22 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
             concatRequest = concatRequest + "threadId:" + threadId + "\n";
         }
 
+        if(format == "html") {
+            concatRequest = concatRequest + "Content-Type: text/html; charset=\"utf-8\"\n";
+        }
+
         if(messageBody != "null") {
             concatRequest = concatRequest + "\n" + messageBody + "\n";
         }
 
-        string encodedRequest = utils:base64encode(concatRequest);
+        string encodedRequest = "";
+
+        if(format == "html") {
+            encodedRequest = strings:replaceAll(utils:base64encode(concatRequest), "\\+","-");
+        } else {
+            encodedRequest = utils:base64encode(concatRequest);
+        }
+
         json createDraftRequest = {"message":{"raw": encodedRequest}};
 
         string createDraftPath = "/v1/users/" + userId + "/drafts";
@@ -108,9 +120,10 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
     @doc:Param{ value : "bcc: To whom sender need to bcc the mail"}
     @doc:Param{ value : "id: Id of the draft to reply"}
     @doc:Param{ value : "threadId: thread Id of the draft to reply"}
+    @doc:Param{ value : "format: Format of the content, can be text (default) or html"}
     @doc:Return{ value : "response object"}
     action updateDraft(ClientConnector g, string draftId, string to, string subject, string from,
-                       string messageBody, string cc , string bcc, string id, string threadId) (message) {
+                       string messageBody, string cc , string bcc, string id, string threadId, string format) (message) {
 
         message request = {};
         string concatRequest = "";
@@ -143,11 +156,22 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
             concatRequest = concatRequest + "threadId:" + threadId + "\n";
         }
 
+        if(format == "html") {
+            concatRequest = concatRequest + "Content-Type: text/html; charset=\"utf-8\"\n";
+        }
+
         if(messageBody != "null") {
             concatRequest = concatRequest + "\n" + messageBody + "\n";
         }
 
-        string encodedRequest = utils:base64encode(concatRequest);
+        string encodedRequest = "";
+
+        if(format == "html") {
+            encodedRequest = strings:replaceAll(utils:base64encode(concatRequest), "\\+","-");
+        } else {
+            encodedRequest = utils:base64encode(concatRequest);
+        }
+
         json updateDraftRequest = {"message":{"raw": encodedRequest}};
 
         string updateDraftPath = "/v1/users/" + userId + "/drafts/" +draftId;
@@ -584,9 +608,10 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
     @doc:Param{ value : "bcc: To whom sender need to bcc the mail"}
     @doc:Param{ value : "id: Id of the mail to send"}
     @doc:Param{ value : "threadId: thread Id of the mail to reply"}
+    @doc:Param{ value : "format: Format of the content, can be text (default) or html"}
     @doc:Return{ value : "response object"}
     action sendMail(ClientConnector g, string to, string subject, string from, string messageBody,
-                    string cc , string bcc, string id, string threadId) (message) {
+                    string cc , string bcc, string id, string threadId, string format) (message) {
 
         message request = {};
         string concatRequest = "";
@@ -611,6 +636,10 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
             concatRequest = concatRequest + "bcc:" + bcc + "\n";
         }
 
+        if(format == "html") {
+           concatRequest = concatRequest + "Content-Type: text/html; charset=\"utf-8\"" + "\n";
+        }
+
         if(id != "null") {
             concatRequest = concatRequest + "id:" + id + "\n";
         }
@@ -623,7 +652,14 @@ connector ClientConnector (string userId, string accessToken, string refreshToke
             concatRequest = concatRequest + "\n" + messageBody + "\n";
         }
 
-        string encodedRequest = utils:base64encode(concatRequest);
+        string encodedRequest = "";
+
+        if(format == "html") {
+            encodedRequest = strings:replaceAll(utils:base64encode(concatRequest),"\\+","-");
+        } else {
+            encodedRequest = utils:base64encode(concatRequest);
+        }
+
         json sendMailRequest = {"raw": encodedRequest};
         string sendMailPath = "/v1/users/" + userId + "/messages/send";
         messages:setJsonPayload(request, sendMailRequest);


### PR DESCRIPTION
This enhances the gmail connector to support HTML content in message body. The sendMail, createDraft and updateDraft methods have been enhanced with this support. The change requires the format to be passed into the connector action where
 it is defaulted to text/plain. To switch on to rich text, 'html' must be set as the format parameter. The code explicitly checks for 'html' and adds the 'Content-Type: text/html' header to the email message. The resultant message body will be encoded using Base64 Alphabet safe for URLs and filenames (https://tools.ietf.org/html/rfc4648#page-7).

The Readme.md and samples have been updated according to the changes to the Connector action and additional tests have been added to GmailConnector_test.bal