### PR TITLE
Remove unnecessary import as alias

### DIFF
--- a/twitter/src/org/wso2/ballerina/connectors/twitter/ClientConnector.bal
+++ b/twitter/src/org/wso2/ballerina/connectors/twitter/ClientConnector.bal
@@ -6,7 +6,7 @@ import ballerina.lang.maps;
 import ballerina.lang.messages;
 import ballerina.lang.strings;
 import ballerina.lang.system;
-import ballerina.net.http as http;
+import ballerina.net.http;
 import ballerina.net.uri;
 import ballerina.utils;
 


### PR DESCRIPTION
This PR removes unnecessary import as alias in the Twitter connector.